### PR TITLE
Fix droping and plugin file inclusion

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -87,7 +87,7 @@ function show_in_admin() {
 
 	// Add drop-ins first.
 	foreach ( get_dropins() as $name => $plugin_file ) {
-		$plugin_data = get_plugin_data( __DIR__ . '/dropins/' . $plugin_file, false, false );
+		$plugin_data = get_plugin_data( dirname( dirname( __DIR__  ) ) . '/dropins/' . $plugin_file, false, false );
 
 		if ( empty ( $plugin_data['Name'] ) ) {
 			$plugin_data['Name'] = $name;
@@ -98,7 +98,7 @@ function show_in_admin() {
 
 	// Add our own mu-plugins to the page
 	foreach ( Platform\get_available_plugins() as $name => $plugin_file ) {
-		$plugin_data = get_plugin_data( __DIR__ . '/plugins/' . $plugin_file, false, false );
+		$plugin_data = get_plugin_data( dirname( dirname( __DIR__  ) ). '/plugins/' . $plugin_file, false, false );
 
 		if ( empty ( $plugin_data['Name'] ) ) {
 			$plugin_data['Name'] = $name;


### PR DESCRIPTION
When the `admin.php` file was moved from the root of the HM Platform directory to the Admin UI plugin, the file paths for loading drop ins and plugins were not adapted.

This fixes this immediate issue, but we should rethink this. It would be recommended to introduce helper functions that return the paths of the drop in and plugin folders of HM Platform. There should be other places where this information would be required.