### PR TITLE
Render bandwidth usage and page generation time graphs

### DIFF
--- a/src/components/Cloud/Bandwidth-Usage.js
+++ b/src/components/Cloud/Bandwidth-Usage.js
@@ -1,12 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import withApiFetch from '../../utils/withApiFetch';
+import orWpError from '../../utils/wp-error';
 import { compose } from 'recompose';
 import { VictoryBar, VictoryChart, VictoryAxis, VictoryTooltip, VictoryLabel } from 'victory';
 
 import DashboardBlock from '../Dashboard-Block';
 import { adminTheme } from '../../victory-theme';
-import { convertBytesToGigabytes } from '../../utils';
+import { getHumanReadableBytes } from '../../utils';
 
 /**
  * Display current bandwidth usage against a site for a rolling 30-day period.
@@ -15,12 +16,14 @@ import { convertBytesToGigabytes } from '../../utils';
  * @param {Array}   data    An array of usage data for the current site.
  */
 const BandwidthUsage = ( { loading, data } ) => {
-	if ( loading ) return '';
-	console.log( data );
+	if ( loading || ! Array.isArray( data ) ) {
+		return '';
+	}
+
 	// Add a label to the usage history for each item.
 	data = data.map( day => {
-		const convertedUsage = convertBytesToGigabytes( day.usage );
-		day.label = `${ new Date( day.date ).toLocaleDateString() } \r\n ${ convertedUsage } GB`
+		const humanReadableBytes = getHumanReadableBytes( day.usage );
+		day.label = `${ new Date( day.date ).toLocaleDateString() } \r\n ${ humanReadableBytes }`
 
 		return day;
 	} );
@@ -36,12 +39,12 @@ const BandwidthUsage = ( { loading, data } ) => {
 			<VictoryLabel
 				x={ 350 }
 				y={ 25 }
-				text={ `${ convertBytesToGigabytes( totalBytes ) } GB cumulative` }
+				text={ `${ getHumanReadableBytes( totalBytes ) } cumulative` }
 			/>
 			<VictoryAxis
 				dependentAxis
 				tickCount={ 5 }
-				tickFormat={ y => `${ convertBytesToGigabytes( y ) } GB` }
+				tickFormat={ y => getHumanReadableBytes( y ) }
 			/>
 			<VictoryAxis
 				label="(Date)"
@@ -57,7 +60,7 @@ const BandwidthUsage = ( { loading, data } ) => {
 			/>
 			<VictoryBar
 				data={ data }
-				labelComponent={<VictoryTooltip/>}
+				labelComponent={ <VictoryTooltip/> }
 				x="date"
 				y="usage"
 			/>

--- a/src/components/Cloud/Bandwidth-Usage.js
+++ b/src/components/Cloud/Bandwidth-Usage.js
@@ -68,15 +68,19 @@ const BandwidthUsage = ( { loading, data } ) => {
 	</DashboardBlock>
 }
 
-BandwidthUsage.defaultProps = { usageHistory: [] }
+BandwidthUsage.defaultProps = { data: [] }
 
-//BandwidthUsage.propTypes = {
-	//data: PropTypes.arrayOf( PropTypes.shape( {
-		//usage: PropTypes.number,
-		//date:  PropTypes.string,
-	//} ) ),
-	//loading: PropTypes.bool,
-//}
+BandwidthUsage.propTypes = {
+	data: orWpError(
+		PropTypes.arrayOf(
+			PropTypes.shape( {
+				usage: PropTypes.number,
+				date:  PropTypes.string,
+			} )
+		)
+	),
+	loading: PropTypes.bool
+};
 
 const BandwidthUsageWithData = compose(
 	withApiFetch( 'hm-stack/v1/bandwidth-usage/' )

--- a/src/components/Cloud/Bandwidth-Usage.js
+++ b/src/components/Cloud/Bandwidth-Usage.js
@@ -1,5 +1,7 @@
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
+import withApiFetch from '../../utils/withApiFetch';
+import { compose } from 'recompose';
 import { VictoryBar, VictoryChart, VictoryAxis, VictoryTooltip, VictoryLabel } from 'victory';
 
 import DashboardBlock from '../Dashboard-Block';
@@ -13,6 +15,8 @@ import { convertBytesToGigabytes } from '../../utils';
  * @param {Array}   data    An array of usage data for the current site.
  */
 const BandwidthUsage = ( { loading, data } ) => {
+	if ( loading ) return '';
+	console.log( data );
 	// Add a label to the usage history for each item.
 	data = data.map( day => {
 		const convertedUsage = convertBytesToGigabytes( day.usage );
@@ -63,12 +67,16 @@ const BandwidthUsage = ( { loading, data } ) => {
 
 BandwidthUsage.defaultProps = { usageHistory: [] }
 
-BandwidthUsage.propTypes = {
-	data: PropTypes.arrayOf( PropTypes.shape( {
-		usage: PropTypes.number,
-		date:  PropTypes.string,
-	} ) ),
-	loading: PropTypes.boolean,
-}
+//BandwidthUsage.propTypes = {
+	//data: PropTypes.arrayOf( PropTypes.shape( {
+		//usage: PropTypes.number,
+		//date:  PropTypes.string,
+	//} ) ),
+	//loading: PropTypes.bool,
+//}
 
-export default BandwidthUsage;
+const BandwidthUsageWithData = compose(
+	withApiFetch( 'hm-stack/v1/bandwidth-usage/' )
+)( BandwidthUsage );
+
+export default BandwidthUsageWithData;

--- a/src/components/Cloud/Page-Generation-Time.js
+++ b/src/components/Cloud/Page-Generation-Time.js
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
+import withApiFetch from '../../utils/withApiFetch';
+import { compose } from 'recompose';
 import { VictoryLine, VictoryChart, VictoryAxis, VictoryTooltip } from 'victory';
 
 import DashboardBlock from '../Dashboard-Block';
@@ -12,6 +14,10 @@ import { adminTheme } from '../../victory-theme';
  * @param {Array}   data    An array of server response data for the current site.
  */
 const PageGenerationTime = ( { loading, data } ) => {
+
+	console.log( data );
+
+	if ( loading || ! Array.isArray( data ) ) return '';
 	const highestTime = data.reduce( ( carry, item ) => { return item.time > carry ? item.time : carry }, 0 );
 
 	return <DashboardBlock title="Page Generation Time" isLoading={ loading }>
@@ -27,7 +33,7 @@ const PageGenerationTime = ( { loading, data } ) => {
 			<VictoryAxis
 				label="(Date)"
 				tickCount={ 7 }
-				tickFormat={ x => new Date( x ).getDate() }
+				tickFormat={ x => { console.log( x); return new Date( x ).getDate(); } }
 				style={ { grid: {
 						fill: "none",
 						stroke: "none",
@@ -53,11 +59,21 @@ const PageGenerationTime = ( { loading, data } ) => {
 PageGenerationTime.defaultProps = { data: [] }
 
 PageGenerationTime.propTypes = {
-	data: PropTypes.arrayOf( PropTypes.shape( {
-		time: PropTypes.number,
-		date: PropTypes.string,
-	} ) ),
-	loading: PropTypes.boolean,
+	data: PropTypes.oneOfType([
+		PropTypes.arrayOf( PropTypes.shape( {
+			time: PropTypes.number,
+			date: PropTypes.string,
+		} ) ),
+		PropTypes.shape( {
+			code: PropTypes.string,
+			message: PropTypes.string
+		} )
+	] ),
+	loading: PropTypes.bool
 }
 
-export default PageGenerationTime;
+const PageGenerationTimeWithData = compose(
+	withApiFetch( 'hm-stack/v1/page-generation/' )
+)( PageGenerationTime );
+
+export default PageGenerationTimeWithData;

--- a/src/components/Cloud/index.js
+++ b/src/components/Cloud/index.js
@@ -4,6 +4,8 @@ import DashboardWrapper from '../Dashboard-Wrapper';
 import PullRequests from './Pull-Requests';
 import EnvironmentData from './Environment-Data';
 import ContactDetails from './Contact-Details';
+import PageGenerationTime from './Page-Generation-Time';
+import BandwidthUsage from './Bandwidth-Usage';
 
 class Cloud extends React.Component {
 	render() {
@@ -14,6 +16,8 @@ class Cloud extends React.Component {
 					<EnvironmentData />
 					<PullRequests />
 					<ContactDetails />
+					<PageGenerationTime />
+					<BandwidthUsage />
 				</DashboardWrapper>
 			</Fragment>
 		);

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -70,11 +70,14 @@ export const getTimeSince = time => {
 };
 
 /**
- * Convert bytes to gigabytes and return a nicely formatted number.
+ * Convert bytes to MB, GB, etc. and return a nicely formatted number.
  *
- * @param bytes
+ * @param {Number} bytes
  * @returns {string}
  */
-export const convertBytesToGigabytes = bytes => {
-	return Number( bytes / 1073741824 ).toLocaleString( undefined, { maximumFractionDigits: 0 } );
+export const getHumanReadableBytes = bytes => {
+	const suffixes = [ 'b', 'KB', 'MB', 'GB', 'TB' ];
+	const exp = parseInt( Math.log( bytes ) / Math.log( 1024 ) );
+
+	return Number( bytes / Math.pow( 1024, exp ) ).toLocaleString( undefined, { maximumFractionDigits: 0 } ) + ' ' + suffixes[ exp ];
 }


### PR DESCRIPTION
Updates the "Cloud" page of HM-PLatform dashboard to render page generation time and total bandwidth transfer graphs, as populated by HM Stack API endpoints that proxy through to the AWS CloudWatch API.

See https://github.com/humanmade/hm-cloud-plugin/issues/3 and https://github.com/humanmade/hm-cloud-plugin/issues/1.

~~This PR depends on https://github.com/humanmade/hm-platform/pull/80 to be merged first to make these endpoints functional.~~ (Merged)